### PR TITLE
Blacklist JMX classes from PowerMock

### DIFF
--- a/elucidate-server/src/test/java/com/digirati/elucidate/test/repository/impl/AnnotationCollectionStoreRepositoryJDBCImplTest.java
+++ b/elucidate-server/src/test/java/com/digirati/elucidate/test/repository/impl/AnnotationCollectionStoreRepositoryJDBCImplTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
@@ -34,6 +35,7 @@ import com.github.jsonldjava.utils.JsonUtils;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AnnotationCollectionStoreRepositoryJDBCImpl.class)
+@PowerMockIgnore({"javax.management.*"})
 public class AnnotationCollectionStoreRepositoryJDBCImplTest extends AbstractTest {
 
     private JdbcTemplate jdbcTemplate;

--- a/elucidate-server/src/test/java/com/digirati/elucidate/test/repository/impl/AnnotationStoreRepositoryJDBCImplTest.java
+++ b/elucidate-server/src/test/java/com/digirati/elucidate/test/repository/impl/AnnotationStoreRepositoryJDBCImplTest.java
@@ -9,6 +9,7 @@ import com.github.jsonldjava.utils.JsonUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
@@ -30,6 +31,7 @@ import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AnnotationStoreRepositoryJDBCImpl.class)
+@PowerMockIgnore({"javax.management.*"})
 public class AnnotationStoreRepositoryJDBCImplTest extends AbstractTest {
 
     private JdbcTemplate jdbcTemplate;

--- a/elucidate-server/src/test/java/com/digirati/elucidate/test/service/impl/W3CAnnotationServiceImplTest.java
+++ b/elucidate-server/src/test/java/com/digirati/elucidate/test/service/impl/W3CAnnotationServiceImplTest.java
@@ -9,6 +9,7 @@ import com.digirati.elucidate.repository.AnnotationStoreRepository;
 import com.digirati.elucidate.service.query.AbstractAnnotationService;
 import com.digirati.elucidate.service.query.impl.W3CAnnotationServiceImpl;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -16,6 +17,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*"})
 public class W3CAnnotationServiceImplTest extends AbstractAnnotationServiceImplTest<W3CAnnotation, W3CAnnotationCollection> {
 
     @Override


### PR DESCRIPTION
Prevents ClassLoader/verifier errors during tests when PowerMock attempts to
mock a protected class.