### PR TITLE
Don't fail at startup when auth is disabled and an auth key is configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-# This Dockerfile is ran by Maven during the `package` phase.
-# If running manually it should be built from the elucidate-server
-# module after building `annotations.war` artifact.
+FROM maven:latest AS build
+
+COPY . /opt/elucidate
+WORKDIR /opt/elucidate
+RUN mvn -f elucidate-parent/pom.xml package
 
 # We use a JRE 10 image so the JVM is able to discover Docker's
 # memory/cpu cgroup settings.
-FROM tomcat:8-jre10
+FROM tomcat:8-jre8
 EXPOSE 8080
 
-ARG ARTIFACT_NAME="annotation.war"
-ADD target/${ARTIFACT_NAME} /usr/local/tomcat/webapps/annotation.war
+COPY --from=build /opt/elucidate/elucidate-server/target/annotation.war /usr/local/tomcat/webapps/annotation.war
 
 # An overridable option that points Spring to a log4j config file.
 # The default is a configuratoin that only logs to the console.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3"
+services:
+  annotation-db:
+    container_name: madoc-platform-postgres
+    image: postgres
+    restart: always
+    environment:
+      - POSTGRES_PASSWORD=example
+      - POSTGRES_DB=annotations
+    ports:
+      - "5432:5432"
+
+  annotation-server:
+    container_name: madoc-platform-annotation-server
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    links:
+      - annotation-db:db
+    environment:
+      - DATABASE_USER=postgres
+      - CATALINA_OPTS=-Ddb.url=jdbc:postgresql://db:5432/annotations -Ddb.user="postgres" -Ddb.password="example"
+    ports:
+      - 8889:8080

--- a/elucidate-server/pom.xml
+++ b/elucidate-server/pom.xml
@@ -24,27 +24,6 @@
 					<warName>annotation</warName>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>com.spotify</groupId>
-				<artifactId>dockerfile-maven-plugin</artifactId>
-				<version>1.4.3</version>
-				<executions>
-					<execution>
-						<id>default</id>
-						<goals>
-							<goal>build</goal>
-							<goal>push</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<repository>dlcs/elucidate-server</repository>
-					<tag>${project.version}</tag>
-					<buildArgs>
-						<ARTIFACT_NAME>${project.build.finalName}.war</ARTIFACT_NAME>
-					</buildArgs>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/elucidate-server/src/main/java/com/digirati/elucidate/infrastructure/config/AuthConfig.java
+++ b/elucidate-server/src/main/java/com/digirati/elucidate/infrastructure/config/AuthConfig.java
@@ -151,6 +151,10 @@ public class AuthConfig implements ResourceServerConfigurer {
 
     @Bean
     JwtAccessTokenConverter accessTokenConverter() {
+        if (!authEnabled) {
+            return new JwtAccessTokenConverter();
+        }
+
         if (StringUtils.isEmpty(verifierKey)) {
             throw new IllegalStateException(MISSING_TOKEN_KEY_ERROR);
         }


### PR DESCRIPTION
Also re-organizes the Docker build to make it a little easier to work with in an environment where only Docker is available (and no Java tooling, for example).