### PR TITLE
fix(sql): fix SETOF annotation_get uses after oauth changes

### DIFF
--- a/elucidate-server/src/main/resources/database/liquibase-changelog.xml
+++ b/elucidate-server/src/main/resources/database/liquibase-changelog.xml
@@ -460,4 +460,34 @@
           relativeToChangelogFile="true"
           path="sql/migrations/v001/05_add_annotation_security_collection.sql"/>
     </changeSet>
+    <changeSet id="73" author="hairmare">
+        <sqlFile splitStatements="false"
+          relativeToChangelogFile="true"
+          path="sql/migrations/v002/01_fix_annotation_delete.sql"/>
+    </changeSet>
+    <changeSet id="74" author="hairmare">
+        <sqlFile splitStatements="false"
+          relativeToChangelogFile="true"
+          path="sql/migrations/v002/02_fix_annotation_search_by_creator.sql"/>
+    </changeSet>
+    <changeSet id="75" author="hairmare">
+        <sqlFile splitStatements="false"
+          relativeToChangelogFile="true"
+          path="sql/migrations/v002/03_fix_annotation_search_by_generator.sql"/>
+    </changeSet>
+    <changeSet id="76" author="hairmare">
+        <sqlFile splitStatements="false"
+          relativeToChangelogFile="true"
+          path="sql/migrations/v002/04_fix_annotation_search_by_target.sql"/>
+    </changeSet>
+    <changeSet id="77" author="hairmare">
+        <sqlFile splitStatements="false"
+          relativeToChangelogFile="true"
+          path="sql/migrations/v002/05_fix_annotation_search_by_temporal.sql"/>
+    </changeSet>
+    <changeSet id="78" author="hairmare">
+        <sqlFile splitStatements="false"
+          relativeToChangelogFile="true"
+          path="sql/migrations/v002/06_fix_annotation_search_by_body.sql"/>
+    </changeSet>
 </databaseChangeLog>

--- a/elucidate-server/src/main/resources/database/sql/migrations/v002/01_fix_annotation_delete.sql
+++ b/elucidate-server/src/main/resources/database/sql/migrations/v002/01_fix_annotation_delete.sql
@@ -1,0 +1,61 @@
+-- Function: public.annotation_delete(character varying, character varying)
+
+-- DROP FUNCTION public.annotation_delete(character varying, character varying);
+
+CREATE OR REPLACE FUNCTION public.annotation_delete(
+    _collectionid character varying,
+    _annotationid character varying)
+RETURNS SETOF annotation_get AS
+$BODY$
+    BEGIN
+        UPDATE
+            annotation
+        SET
+            deleted = true,
+            modifieddatetime = now()
+        WHERE
+            collectionid = (
+                SELECT
+                    id
+                FROM
+                    annotation_collection
+                WHERE
+                    collectionid = _collectionid
+                    AND deleted = false
+                ORDER BY
+                    modifieddatetime DESC LIMIT 1
+            )
+            AND annotationid = _annotationid
+            AND deleted = false;
+        RETURN QUERY
+            SELECT
+                a.annotationid,
+                a.cachekey,
+                ac.collectionid,
+                a.createddatetime,
+                a.deleted,
+                a.json,
+                a.modifieddatetime,
+                a.id,
+                ao.user_id as ownerid,
+                agm.group_ids
+            FROM
+                annotation a
+                    LEFT JOIN annotation_collection ac ON a.collectionid = ac.id
+                    LEFT JOIN annotation_owner ao ON ao.annotation_id = a.id
+                    LEFT JOIN annotation_group_memberships agm ON agm.annotation_id = a.id
+            WHERE
+                ac.collectionid = _collectionid
+                AND ac.deleted = false
+                AND a.annotationid = _annotationid
+                AND a.deleted = true
+            ORDER BY
+                modifieddatetime DESC LIMIT 1;
+    END;
+$BODY$
+LANGUAGE plpgsql VOLATILE COST 100 ROWS 1000;
+
+ALTER FUNCTION public.annotation_delete(character varying, character varying) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_delete(character varying, character varying) TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_delete(character varying, character varying) TO annotations_role;
+REVOKE ALL ON FUNCTION public.annotation_delete(character varying, character varying) FROM public;

--- a/elucidate-server/src/main/resources/database/sql/migrations/v002/02_fix_annotation_search_by_creator.sql
+++ b/elucidate-server/src/main/resources/database/sql/migrations/v002/02_fix_annotation_search_by_creator.sql
@@ -1,0 +1,269 @@
+-- Function: public.annotation_search_by_creator(boolean, boolean, boolean, character varying, character varying, boolean)
+
+-- DROP FUNCTION public.annotation_search_by_creator(boolean, boolean, boolean, character varying, character varying, boolean);
+
+CREATE OR REPLACE FUNCTION public.annotation_search_by_creator(
+    _searchannotations boolean,
+    _searchbodies boolean,
+    _searchtargets boolean,
+    _type character varying,
+    _value character varying,
+    _strict boolean)
+RETURNS SETOF annotation_get AS
+$BODY$
+    BEGIN
+        RETURN QUERY
+            SELECT DISTINCT
+                a.annotationid,
+                a.cachekey,
+                ac.collectionid,
+                a.createddatetime,
+                a.deleted,
+                a.json,
+                a.modifieddatetime,
+                a.id,
+                ao.user_id as ownerid,
+                agm.group_ids
+            FROM
+                annotation AS a
+                    LEFT JOIN annotation_collection AS ac ON a.collectionid = ac.id
+                    LEFT JOIN annotation_owner ao ON ao.annotation_id = a.id
+                    LEFT JOIN annotation_group_memberships agm ON agm.annotation_id = a.id
+            WHERE
+                a.id IN (
+                    SELECT
+                        a.id
+                    FROM
+                        annotation AS a
+                            LEFT JOIN annotation_collection AS ac ON a.collectionid = ac.id
+                            LEFT JOIN annotation_agent AS aa ON aa.annotationid = a.id
+                            LEFT JOIN annotation_agent_email AS aae ON aae.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_email_sha1 AS aaes ON aaes.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_name AS aan ON aan.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_type AS aat ON aat.annotationagentid = aa.id
+                    WHERE
+                        a.deleted = false
+                        AND aa.relationshiptype = 'CREATOR'
+                        AND CASE _searchannotations
+                            WHEN true THEN
+                                CASE
+                                    WHEN _type = 'id' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.agentiri = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.agentiri LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'name' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aan.name = _value
+                                                    AND aan.deleted = false
+                                                ELSE
+                                                    aan.name LIKE (_value || '%')
+                                                    AND aan.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'nickname' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.nickname = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.nickname LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'email' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aae.email = _value
+                                                    AND aae.deleted = false
+                                                ELSE
+                                                    aae.email LIKE (_value || '%')
+                                                    AND aae.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'emailsha1' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aaes.emailsha1 = _value
+                                                    AND aaes.deleted = false
+                                                ELSE
+                                                    aaes.emailsha1 LIKE (_value || '%')
+                                                    AND aaes.deleted = false
+                                            END
+                                        )
+                                END
+                            ELSE
+                                (false)
+                            END
+                    UNION
+                    SELECT
+                        a.id
+                    FROM
+                        annotation AS a
+                            LEFT JOIN annotation_body AS ab ON ab.annotationid = a.id
+                            LEFT JOIN annotation_agent AS aa ON aa.bodyid = ab.id
+                            LEFT JOIN annotation_agent_email AS aae ON aae.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_email_sha1 AS aaes ON aaes.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_name AS aan ON aan.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_type AS aat ON aat.annotationagentid = aa.id
+                    WHERE
+                        a.deleted = false
+                        AND aa.relationshiptype = 'CREATOR'
+                        AND CASE _searchbodies
+                            WHEN true THEN
+                                CASE
+                                    WHEN _type = 'id' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.agentiri = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.agentiri LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'name' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aan.name = _value
+                                                    AND aan.deleted = false
+                                                ELSE
+                                                    aan.name LIKE (_value || '%')
+                                                    AND aan.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'nickname' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.nickname = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.nickname LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'email' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aae.email = _value
+                                                    AND aae.deleted = false
+                                                ELSE
+                                                    aae.email LIKE (_value || '%')
+                                                    AND aae.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'emailsha1' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aaes.emailsha1 = _value
+                                                    AND aaes.deleted = false
+                                                ELSE
+                                                    aaes.emailsha1 LIKE (_value || '%')
+                                                    AND aaes.deleted = false
+                                            END
+                                        )
+                                END
+                            ELSE
+                                (false)
+                            END
+                    UNION
+                    SELECT
+                        a.id
+                    FROM
+                        annotation AS a
+                            LEFT JOIN annotation_target AS at ON at.annotationid = a.id
+                            LEFT JOIN annotation_agent AS aa ON aa.targetid = at.id
+                            LEFT JOIN annotation_agent_email AS aae ON aae.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_email_sha1 AS aaes ON aaes.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_name AS aan ON aan.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_type AS aat ON aat.annotationagentid = aa.id
+                    WHERE
+                        a.deleted = false
+                        AND aa.relationshiptype = 'CREATOR'
+                        AND CASE _searchtargets
+                            WHEN true THEN
+                                CASE
+                                    WHEN _type = 'id' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.agentiri = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.agentiri LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'name' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aan.name = _value
+                                                    AND aan.deleted = false
+                                                ELSE
+                                                    aan.name LIKE (_value || '%')
+                                                    AND aan.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'nickname' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.nickname = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.nickname LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'email' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aae.email = _value
+                                                    AND aae.deleted = false
+                                                ELSE
+                                                    aae.email LIKE (_value || '%')
+                                                    AND aae.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'emailsha1' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aaes.emailsha1 = _value
+                                                    AND aaes.deleted = false
+                                                ELSE
+                                                    aaes.emailsha1 LIKE (_value || '%')
+                                                    AND aaes.deleted = false
+                                            END
+                                        )
+                                END
+                            ELSE
+                                (false)
+                            END
+                );
+END;
+$BODY$
+LANGUAGE plpgsql VOLATILE COST 100 ROWS 1000;
+
+ALTER FUNCTION public.annotation_search_by_creator(boolean, boolean, boolean, character varying, character varying, boolean) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_search_by_creator(boolean, boolean, boolean, character varying, character varying, boolean) TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_search_by_creator(boolean, boolean, boolean, character varying, character varying, boolean) TO annotations_role;
+REVOKE ALL ON FUNCTION public.annotation_search_by_creator(boolean, boolean, boolean, character varying, character varying, boolean) FROM public;

--- a/elucidate-server/src/main/resources/database/sql/migrations/v002/03_fix_annotation_search_by_generator.sql
+++ b/elucidate-server/src/main/resources/database/sql/migrations/v002/03_fix_annotation_search_by_generator.sql
@@ -1,0 +1,269 @@
+-- Function: public.annotation_search_by_generator(boolean, boolean, boolean, character varying, character varying, boolean)
+
+-- DROP FUNCTION public.annotation_search_by_generator(boolean, boolean, boolean, character varying, character varying, boolean);
+
+CREATE OR REPLACE FUNCTION public.annotation_search_by_generator(
+    _searchannotations boolean,
+    _searchbodies boolean,
+    _searchtargets boolean,
+    _type character varying,
+    _value character varying,
+    _strict boolean)
+RETURNS SETOF annotation_get AS
+$BODY$
+    BEGIN
+        RETURN QUERY
+            SELECT DISTINCT
+                a.annotationid,
+                a.cachekey,
+                ac.collectionid,
+                a.createddatetime,
+                a.deleted,
+                a.json,
+                a.modifieddatetime,
+                a.id,
+                ao.user_id as ownerid,
+                agm.group_ids
+            FROM
+                annotation AS a
+                    LEFT JOIN annotation_collection AS ac ON a.collectionid = ac.id
+                    LEFT JOIN annotation_owner ao ON ao.annotation_id = a.id
+                    LEFT JOIN annotation_group_memberships agm ON agm.annotation_id = a.id
+            WHERE
+                a.id IN (
+                    SELECT
+                        a.id
+                    FROM
+                        annotation AS a
+                            LEFT JOIN annotation_collection AS ac ON a.collectionid = ac.id
+                            LEFT JOIN annotation_agent AS aa ON aa.annotationid = a.id
+                            LEFT JOIN annotation_agent_email AS aae ON aae.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_email_sha1 AS aaes ON aaes.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_name AS aan ON aan.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_type AS aat ON aat.annotationagentid = aa.id
+                    WHERE
+                        a.deleted = false
+                        AND aa.relationshiptype = 'GENERATOR'
+                        AND CASE _searchannotations
+                            WHEN true THEN
+                                CASE
+                                    WHEN _type = 'id' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.agentiri = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.agentiri LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'name' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aan.name = _value
+                                                    AND aan.deleted = false
+                                                ELSE
+                                                    aan.name LIKE (_value || '%')
+                                                    AND aan.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'nickname' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.nickname = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.nickname LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'email' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aae.email = _value
+                                                    AND aae.deleted = false
+                                                ELSE
+                                                    aae.email LIKE (_value || '%')
+                                                    AND aae.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'emailsha1' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aaes.emailsha1 = _value
+                                                    AND aaes.deleted = false
+                                                ELSE
+                                                    aaes.emailsha1 LIKE (_value || '%')
+                                                    AND aaes.deleted = false
+                                            END
+                                        )
+                                END
+                            ELSE
+                                (false)
+                            END
+                    UNION
+                    SELECT
+                        a.id
+                    FROM
+                        annotation AS a
+                            LEFT JOIN annotation_body AS ab ON ab.annotationid = a.id
+                            LEFT JOIN annotation_agent AS aa ON aa.bodyid = ab.id
+                            LEFT JOIN annotation_agent_email AS aae ON aae.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_email_sha1 AS aaes ON aaes.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_name AS aan ON aan.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_type AS aat ON aat.annotationagentid = aa.id
+                    WHERE
+                        a.deleted = false
+                        AND aa.relationshiptype = 'GENERATOR'
+                        AND CASE _searchbodies
+                            WHEN true THEN
+                                CASE
+                                    WHEN _type = 'id' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.agentiri = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.agentiri LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'name' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aan.name = _value
+                                                    AND aan.deleted = false
+                                                ELSE
+                                                    aan.name LIKE (_value || '%')
+                                                    AND aan.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'nickname' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.nickname = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.nickname LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'email' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aae.email = _value
+                                                    AND aae.deleted = false
+                                                ELSE
+                                                    aae.email LIKE (_value || '%')
+                                                    AND aae.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'emailsha1' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aaes.emailsha1 = _value
+                                                    AND aaes.deleted = false
+                                                ELSE
+                                                    aaes.emailsha1 LIKE (_value || '%')
+                                                    AND aaes.deleted = false
+                                            END
+                                        )
+                                END
+                            ELSE
+                                (false)
+                            END
+                    UNION
+                    SELECT
+                        a.id
+                    FROM
+                        annotation AS a
+                            LEFT JOIN annotation_target AS at ON at.annotationid = a.id
+                            LEFT JOIN annotation_agent AS aa ON aa.targetid = at.id
+                            LEFT JOIN annotation_agent_email AS aae ON aae.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_email_sha1 AS aaes ON aaes.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_name AS aan ON aan.annotationagentid = aa.id
+                            LEFT JOIN annotation_agent_type AS aat ON aat.annotationagentid = aa.id
+                    WHERE
+                        a.deleted = false
+                        AND aa.relationshiptype = 'GENERATOR'
+                        AND CASE _searchtargets
+                            WHEN true THEN
+                                CASE
+                                    WHEN _type = 'id' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.agentiri = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.agentiri LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'name' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aan.name = _value
+                                                    AND aan.deleted = false
+                                                ELSE
+                                                    aan.name LIKE (_value || '%')
+                                                    AND aan.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'nickname' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aa.nickname = _value
+                                                    AND aa.deleted = false
+                                                ELSE
+                                                    aa.nickname LIKE (_value || '%')
+                                                    AND aa.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'email' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aae.email = _value
+                                                    AND aae.deleted = false
+                                                ELSE
+                                                    aae.email LIKE (_value || '%')
+                                                    AND aae.deleted = false
+                                            END
+                                        )
+                                    WHEN _type = 'emailsha1' THEN
+                                        (
+                                            CASE _strict
+                                                WHEN true THEN
+                                                    aaes.emailsha1 = _value
+                                                    AND aaes.deleted = false
+                                                ELSE
+                                                    aaes.emailsha1 LIKE (_value || '%')
+                                                    AND aaes.deleted = false
+                                            END
+                                        )
+                                END
+                            ELSE
+                                (false)
+                            END
+                );
+END;
+$BODY$
+LANGUAGE plpgsql VOLATILE COST 100 ROWS 1000;
+
+ALTER FUNCTION public.annotation_search_by_generator(boolean, boolean, boolean, character varying, character varying, boolean) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_search_by_generator(boolean, boolean, boolean, character varying, character varying, boolean) TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_search_by_generator(boolean, boolean, boolean, character varying, character varying, boolean) TO annotations_role;
+REVOKE ALL ON FUNCTION public.annotation_search_by_generator(boolean, boolean, boolean, character varying, character varying, boolean) FROM public;

--- a/elucidate-server/src/main/resources/database/sql/migrations/v002/04_fix_annotation_search_by_target.sql
+++ b/elucidate-server/src/main/resources/database/sql/migrations/v002/04_fix_annotation_search_by_target.sql
@@ -1,0 +1,135 @@
+-- Function: public.annotation_search_by_target(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying)
+
+-- DROP FUNCTION public.annotation_search_by_target(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying);
+
+CREATE OR REPLACE FUNCTION public.annotation_search_by_target(
+    _searchids boolean,
+    _searchsources boolean,
+    _value character varying,
+    _strict boolean,
+    _x integer,
+    _y integer,
+    _w integer,
+    _h integer,
+    _start integer,
+    _end integer,
+    _creatoriri character varying,
+    _generatoriri character varying)
+  RETURNS SETOF annotation_get AS
+$BODY$
+    BEGIN
+        RETURN QUERY
+            SELECT DISTINCT
+                a.annotationid,
+                a.cachekey,
+                ac.collectionid,
+                a.createddatetime,
+                a.deleted,
+                a.json,
+                a.modifieddatetime,
+                a.id,
+                ao.user_id as ownerid,
+                agm.group_ids
+            FROM
+                annotation AS a
+                    LEFT JOIN annotation_collection AS ac ON a.collectionid = ac.id
+                    LEFT JOIN annotation_target AS at ON at.annotationid = a.id
+                    LEFT JOIN annotation_selector AS asl ON asl.targetid = at.id
+                    LEFT JOIN annotation_agent AS agc ON agc.targetid = at.id
+                    LEFT JOIN annotation_agent AS agg ON agg.targetid = at.id
+                    LEFT JOIN annotation_owner ao ON ao.annotation_id = a.id
+                    LEFT JOIN annotation_group_memberships agm ON agm.annotation_id = a.id
+            WHERE
+                (CASE _searchids
+                    WHEN true THEN
+                        (
+                            CASE _strict
+                                WHEN true THEN
+                                    at.targetiri = _value
+                                ELSE
+                                    at.targetiri LIKE (_value || '%')
+                            END
+                        )
+                    ELSE
+                        false
+                END
+                OR CASE _searchsources
+                    WHEN true THEN
+                        (
+                            CASE _strict
+                                WHEN true THEN
+                                    at.sourceiri = _value
+                                ELSE
+                                    at.sourceiri LIKE (_value || '%')
+                            END
+                        )
+                    ELSE
+                        false
+                END)
+                AND CASE ((_start IS NOT NULL AND _end IS NOT NULL) OR (_x IS NOT NULL AND _y IS NOT NULL AND _w IS NOT NULL AND _h IS NOT NULL))
+                    WHEN true THEN
+                        (
+                            at.id IN (
+                                SELECT
+                                    targetid
+                                FROM
+                                    annotation_selector
+                                WHERE
+                                    CASE (_x IS NOT NULL AND _y IS NOT NULL AND _w IS NOT NULL AND _h IS NOT NULL)
+                                        WHEN true THEN
+                                            (
+                                                (_x + _w) > x
+                                                AND _x < (x + w)
+                                                AND (_y + _h) > y
+                                                AND _y < (y + h)
+                                                AND type = 'http://www.w3.org/ns/oa#FragmentSelector'
+                                                AND deleted = false
+                                            )
+                                        ELSE
+                                            (true)
+                                    END
+                                INTERSECT
+                                SELECT
+                                    targetid
+                                FROM
+                                    annotation_selector
+                                WHERE
+                                    CASE (_start IS NOT NULL AND _end IS NOT NULL)
+                                        WHEN true THEN
+                                            (
+                                                _start < "end"
+                                                AND _end > start
+                                                AND type = 'http://www.w3.org/ns/oa#FragmentSelector'
+                                                AND deleted = false
+                                            )
+                                        ELSE
+                                            (true)
+                                    END
+                            )
+                        )
+
+                    ELSE
+                        true
+                END
+                AND CASE (_creatoriri IS NOT NULL)
+                    WHEN true THEN
+                        (agc.agentiri = _creatoriri AND agc.relationshiptype = 'CREATOR')
+                    ELSE
+                        true
+                END
+                AND CASE (_generatoriri IS NOT NULL)
+                    WHEN true THEN
+                        (agg.agentiri = _generatoriri AND agg.relationshiptype = 'GENERATOR')
+                    ELSE
+                        true
+                END
+                AND a.deleted = false
+                AND at.deleted = false;
+    END;
+$BODY$
+LANGUAGE plpgsql VOLATILE COST 100 ROWS 1000;
+
+ALTER FUNCTION public.annotation_search_by_target(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_search_by_target(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying) TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_search_by_target(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying) TO annotations_role;
+REVOKE ALL ON FUNCTION public.annotation_search_by_target(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying) FROM public;

--- a/elucidate-server/src/main/resources/database/sql/migrations/v002/05_fix_annotation_search_by_temporal.sql
+++ b/elucidate-server/src/main/resources/database/sql/migrations/v002/05_fix_annotation_search_by_temporal.sql
@@ -1,0 +1,132 @@
+-- Function: public.annotation_search_by_temporal(boolean, boolean, boolean, character varying[], timestamp without time zone)
+
+-- DROP FUNCTION public.annotation_search_by_temporal(boolean, boolean, boolean, character varying[], timestamp without time zone);
+
+CREATE OR REPLACE FUNCTION public.annotation_search_by_temporal(
+    _searchannotations boolean,
+    _searchbodies boolean,
+    _searchtargets boolean,
+    _types character varying[],
+    _since timestamp without time zone)
+RETURNS SETOF annotation_get AS
+$BODY$
+    BEGIN
+        RETURN QUERY
+          SELECT DISTINCT
+              a.annotationid,
+              a.cachekey,
+              ac.collectionid,
+              a.createddatetime,
+              a.deleted,
+              a.json,
+              a.modifieddatetime,
+              a.id,
+              ao.user_id as ownerid,
+              agm.group_ids
+          FROM
+              annotation AS a
+                  LEFT JOIN annotation_collection AS ac ON a.collectionid = ac.id
+                  LEFT JOIN annotation_owner ao ON ao.annotation_id = a.id
+                  LEFT JOIN annotation_group_memberships agm ON agm.annotation_id = a.id
+          WHERE
+              a.id IN (
+                  SELECT
+                      a.id
+                  FROM
+                      annotation AS a
+                          LEFT JOIN annotation_temporal atpc ON atpc.annotationid = a.id
+                          LEFT JOIN annotation_temporal atpm ON atpm.annotationid = a.id
+                          LEFT JOIN annotation_temporal atpg on atpg.annotationid = a.id
+                  WHERE
+                      a.deleted = false
+                      AND CASE _searchannotations
+                          WHEN true THEN
+                              CASE WHEN _types @> ARRAY['CREATED']::character varying[] THEN
+                                  atpc.type = 'CREATED' AND atpc.value >= _since
+                              ELSE
+                                  true
+                              END
+                              AND CASE WHEN _types @> ARRAY['MODIFIED']::character varying[] THEN
+                                  atpm.type = 'MODIFIED' AND atpm.value >= _since
+                              ELSE
+                                  true
+                              END
+                              AND CASE WHEN _types @> ARRAY['GENERATED']::character varying[] THEN
+                                  atpg.type = 'GENERATED' AND atpg.value >= _since
+                              ELSE
+                                  true
+                              END
+                          ELSE
+                              false
+                          END
+                  UNION
+                  SELECT
+                      a.id
+                  FROM
+                      annotation AS a
+                          LEFT JOIN annotation_body ab ON ab.annotationid = a.id
+                          LEFT JOIN annotation_temporal atpc ON atpc.bodyid = ab.id
+                          LEFT JOIN annotation_temporal atpm ON atpm.bodyid = ab.id
+                          LEFT JOIN annotation_temporal atpg on atpg.bodyid = ab.id
+                  WHERE
+                      a.deleted = false
+                      AND CASE _searchbodies
+                          WHEN true THEN
+                              CASE WHEN _types @> ARRAY['CREATED']::character varying[] THEN
+                                  atpc.type = 'CREATED' AND atpc.value >= _since
+                              ELSE
+                                  true
+                              END
+                              AND CASE WHEN _types @> ARRAY['MODIFIED']::character varying[] THEN
+                                  atpm.type = 'MODIFIED' AND atpm.value >= _since
+                              ELSE
+                                  true
+                              END
+                              AND CASE WHEN _types @> ARRAY['GENERATED']::character varying[] THEN
+                                  atpg.type = 'GENERATED' AND atpg.value >= _since
+                              ELSE
+                                  true
+                              END
+                          ELSE
+                              false
+                          END
+                  UNION
+                  SELECT
+                      a.id
+                  FROM
+                      annotation AS a
+                          LEFT JOIN annotation_target at ON at.annotationid = a.id
+                          LEFT JOIN annotation_temporal atpc ON atpc.targetid = at.id
+                          LEFT JOIN annotation_temporal atpm ON atpm.targetid = at.id
+                          LEFT JOIN annotation_temporal atpg on atpg.targetid = at.id
+                  WHERE
+                      a.deleted = false
+                      AND CASE _searchtargets
+                          WHEN true THEN
+                              CASE WHEN _types @> ARRAY['CREATED']::character varying[] THEN
+                                  atpc.type = 'CREATED' AND atpc.value >= _since
+                              ELSE
+                                  true
+                              END
+                              AND CASE WHEN _types @> ARRAY['MODIFIED']::character varying[] THEN
+                                  atpm.type = 'MODIFIED' AND atpm.value >= _since
+                              ELSE
+                                  true
+                              END
+                              AND CASE WHEN _types @> ARRAY['GENERATED']::character varying[] THEN
+                                  atpg.type = 'GENERATED' AND atpg.value >= _since
+                              ELSE
+                                  true
+                              END
+                          ELSE
+                              false
+                          END
+              );
+END;
+$BODY$
+LANGUAGE plpgsql VOLATILE COST 100 ROWS 1000;
+
+ALTER FUNCTION public.annotation_search_by_temporal(boolean, boolean, boolean, character varying[], timestamp without time zone) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_search_by_temporal(boolean, boolean, boolean, character varying[], timestamp without time zone) TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_search_by_temporal(boolean, boolean, boolean, character varying[], timestamp without time zone) TO annotations_role;
+REVOKE ALL ON FUNCTION public.annotation_search_by_temporal(boolean, boolean, boolean, character varying[], timestamp without time zone) FROM public;

--- a/elucidate-server/src/main/resources/database/sql/migrations/v002/06_fix_annotation_search_by_body.sql
+++ b/elucidate-server/src/main/resources/database/sql/migrations/v002/06_fix_annotation_search_by_body.sql
@@ -1,0 +1,135 @@
+-- Function: public.annotation_search_by_body(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying)
+
+-- DROP FUNCTION public.annotation_search_by_body(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying);
+
+CREATE OR REPLACE FUNCTION public.annotation_search_by_body(
+    _searchids boolean,
+    _searchsources boolean,
+    _value character varying,
+    _strict boolean,
+    _x integer,
+    _y integer,
+    _w integer,
+    _h integer,
+    _start integer,
+    _end integer,
+    _creatoriri character varying,
+    _generatoriri character varying)
+  RETURNS SETOF annotation_get AS
+$BODY$
+    BEGIN
+        RETURN QUERY
+            SELECT DISTINCT
+                a.annotationid,
+                a.cachekey,
+                ac.collectionid,
+                a.createddatetime,
+                a.deleted,
+                a.json,
+                a.modifieddatetime,
+                a.id,
+                ao.user_id as ownerid,
+                agm.group_ids
+            FROM
+                annotation AS a
+                    LEFT JOIN annotation_collection AS ac ON a.collectionid = ac.id
+                    LEFT JOIN annotation_body AS ab ON ab.annotationid = a.id
+                    LEFT JOIN annotation_selector AS asl ON asl.bodyid = ab.id
+                    LEFT JOIN annotation_agent AS agc ON agc.bodyid = ab.id
+                    LEFT JOIN annotation_agent AS agg ON agg.bodyid = ab.id
+                    LEFT JOIN annotation_owner ao ON ao.annotation_id = a.id
+                    LEFT JOIN annotation_group_memberships agm ON agm.annotation_id = a.id
+            WHERE
+                (CASE _searchids
+                    WHEN true THEN
+                        (
+                            CASE _strict
+                                WHEN true THEN
+                                    ab.bodyiri = _value
+                                ELSE
+                                    ab.bodyiri LIKE (_value || '%')
+                            END
+                        )
+                    ELSE
+                        false
+                END
+                OR CASE _searchsources
+                    WHEN true THEN
+                        (
+                            CASE _strict
+                                WHEN true THEN
+                                    ab.sourceiri = _value
+                                ELSE
+                                    ab.sourceiri LIKE (_value || '%')
+                            END
+                        )
+                    ELSE
+                        false
+                END)
+                AND CASE ((_start IS NOT NULL AND _end IS NOT NULL) OR (_x IS NOT NULL AND _y IS NOT NULL AND _w IS NOT NULL AND _h IS NOT NULL))
+                    WHEN true THEN
+                        (
+                            ab.id IN (
+                                SELECT
+                                    bodyid
+                                FROM
+                                    annotation_selector
+                                WHERE
+                                    CASE (_x IS NOT NULL AND _y IS NOT NULL AND _w IS NOT NULL AND _h IS NOT NULL)
+                                        WHEN true THEN
+                                            (
+                                                (_x + _w) > x
+                                                AND _x < (x + w)
+                                                AND (_y + _h) > y
+                                                AND _y < (y + h)
+                                                AND type = 'http://www.w3.org/ns/oa#FragmentSelector'
+                                                AND deleted = false
+                                            )
+                                        ELSE
+                                            (true)
+                                    END
+                                INTERSECT
+                                SELECT
+                                    bodyid
+                                FROM
+                                    annotation_selector
+                                WHERE
+                                    CASE (_start IS NOT NULL AND _end IS NOT NULL)
+                                        WHEN true THEN
+                                            (
+                                                _start < "end"
+                                                AND _end > start
+                                                AND type = 'http://www.w3.org/ns/oa#FragmentSelector'
+                                                AND deleted = false
+                                            )
+                                        ELSE
+                                            (true)
+                                    END
+                            )
+                        )
+
+                    ELSE
+                        true
+                END
+                AND CASE (_creatoriri IS NOT NULL)
+                    WHEN true THEN
+                        (agc.agentiri = _creatoriri AND agc.relationshiptype = 'CREATOR')
+                    ELSE
+                        true
+                END
+                AND CASE (_generatoriri IS NOT NULL)
+                    WHEN true THEN
+                        (agg.agentiri = _generatoriri AND agg.relationshiptype = 'GENERATOR')
+                    ELSE
+                        true
+                END
+                AND a.deleted = false
+                AND ab.deleted = false;
+    END;
+$BODY$
+LANGUAGE plpgsql VOLATILE COST 100 ROWS 1000;
+
+ALTER FUNCTION public.annotation_search_by_body(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_search_by_body(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying) TO postgres;
+GRANT EXECUTE ON FUNCTION public.annotation_search_by_body(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying) TO annotations_role;
+REVOKE ALL ON FUNCTION public.annotation_search_by_body(boolean, boolean, character varying, boolean, integer, integer, integer, integer, integer, integer, character varying, character varying) FROM public;


### PR DESCRIPTION
After #100 I realized that there are a couple more SQL functions that don't work. This adds `ao.user_id as ownerid` and `agm.group_ids` to all select statements that need those fields. The fields are joined using `LEFT JOIN annotation_owner ao ON ao.annotation_id = a.id LEFT JOIN annotation_group_memberships agm ON agm.annotation_id = a.id` in all cases.

This should fix all the searches as well as annotation deleting as described in #101. 

I also re-added a copy of change from #100 to this PR so that it can also get applied on instances where the `v001` migration was already applied.

Fixes #101 