### PR TITLE
feat(server): anonymous read access to /w3c/ and /oa/ when auth enabled (optional)

### DIFF
--- a/elucidate-server/src/main/java/com/digirati/elucidate/infrastructure/security/impl/JwtUserSecurityDetailsContext.java
+++ b/elucidate-server/src/main/java/com/digirati/elucidate/infrastructure/security/impl/JwtUserSecurityDetailsContext.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 
 import java.util.Collection;
 
@@ -20,6 +21,9 @@ public class JwtUserSecurityDetailsContext implements UserSecurityDetailsContext
     @Override
     public boolean isAuthorized(Permission operation, AbstractAnnotation annotation) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof AnonymousAuthenticationToken) {
+            return true;
+        }
         UserSecurityDetails details = (UserSecurityDetails) auth.getPrincipal();
         Collection<? extends GrantedAuthority> roles = auth.getAuthorities();
 

--- a/elucidate-server/src/main/resources/eludicate-server.properties
+++ b/elucidate-server/src/main/resources/eludicate-server.properties
@@ -145,6 +145,7 @@ auth.enabled=false
 auth.token.verifierType=secret
 auth.token.verifierKey=
 auth.token.uidProperties=sub,user_name
+auth.anonReadAccess=false
 
 # Generator to use when generating Security Group IDs
 annotation.group.id.generator=com.digirati.elucidate.infrastructure.generator.impl.UUIDIDGeneratorImpl


### PR DESCRIPTION
This is a **feature request**. I would like to be able to use eludicate as a backend for some public frontends while still keeping `auth.enabled=true`.

**How to reproduce**
Deploy server, enable and configure auth.

**Expected results**
1. Managing the users/groups, creating/updating annotations + collections is only possible for logged in users ✅ 
2. There is a way to allow public (GET) access to annotations and collections and the respective search interfaces 🔴 

**Actual results**
The only way to allow anonymous access I can think of are middleware based approaches that always involve authenticaded access to the server when `auth.enabled=true`.

**Additional Info**
The code in this branch is an example attempt at implementing this by allowing anonymous access on GET requests for all `/w3c/*` and `/oa/*` routes. Non ephemeral methods (the user/group admin parts and creating/mutation annotations) still need proper auth when `auth.enabled=true`.

The new feature can configured using the `auth.anonReadAccess` boolean property.

Adding a middleware adds complexity when starting off with w3c annotations. My primary motivation for using elucidate over other servers is that what is needed to run it is simple and doesn't required multiple nosql stores, queues and, indexing services. This feature makes it easier to get up and running in cases like mine where I am greenfielding a linked data experiment and can live without having full fledged policy/rbac/whatever control over access to annotations.

I'm not a Java nor a Sprint developer so please be very critical of the actual contents of this PR. This only covers aone way to acheive this that will work for my current use case, I'm open to a discussion about possible alternative ways to achieve the laid out requirements, so I wont be mad if we don't merge it as is 😉 

To get this running on my dev box I also did some work on getting it running with java 11... Let me know if you would be interested in a PR containing that. I'm hesitant to propose it as a PR since it's not at a stage where it won't break java 8. fwiw updating to java 11 would pave the way to an updated oauth client that supports jwks, This would have saved me quite some time during my auth config.